### PR TITLE
'file' lookup already searches in 'playbook_dir'

### DIFF
--- a/roles/tower-setup/defaults/main.yaml
+++ b/roles/tower-setup/defaults/main.yaml
@@ -29,8 +29,7 @@ tower_setup_license_configure: False
 tower_setup_license_file: /root/tower-license.json
 
 tower_setup_inventory_file: /etc/tower-setup/tower-setup-inventory.yaml
-# TODO: Is there a better way ?
-tower_setup_inventory: "{{ lookup('file', playbook_dir + '/../inventory.yaml') | from_yaml }}"
+tower_setup_inventory: "{{ lookup('file', 'inventory.yaml') | from_yaml }}"
 
 tower_setup_cli_config:
   host: "http://localhost"


### PR DESCRIPTION
`file` lookup already searches in `playbook_dir`. By default the following paths are tested (according to `strace`) in this order:
* roles/tower-setup/files/inventory.yaml
* roles/tower-setup/inventory.yaml
* roles/tower-setup/tasks/files/inventory.yaml
* roles/tower-setup/tasks/inventory.yaml
* {{ playbook_dir }}/files/inventory.yaml
* {{ playbook_dir }}/inventory.yaml

See also https://docs.ansible.com/ansible/devel/user_guide/playbook_pathing.html#the-magic-of-local-paths.