### PR TITLE
Remove admin credentials from tower_cli.cfg

### DIFF
--- a/roles/tower-config/defaults/main.yaml
+++ b/roles/tower-config/defaults/main.yaml
@@ -16,6 +16,9 @@
 #  You should have received a copy of the GNU General Public License
 #  along with ansible-tower-cicd.  If not, see <http://www.gnu.org/licenses/>.
 
+tower_admin_username: admin
+tower_admin_password: password
+
 # Whether tasks should be logged or not to hide potentially sensitive
 # information from the console.
 tower_config_no_log: True

--- a/roles/tower-config/tasks/main.yaml
+++ b/roles/tower-config/tasks/main.yaml
@@ -22,6 +22,8 @@
     description: "{{ item.description | default(omit) }}"
     state: "{{ item.state | default(omit) }}"
     tower_verify_ssl: "{{ tower_config_verify_ssl }}"
+    tower_username: "{{ tower_admin_username }}"
+    tower_password: "{{ tower_admin_password }}"
   no_log: "{{ tower_config_no_log }}"
   with_items: "{{ tower_config_organizations }}"
 
@@ -31,6 +33,8 @@
     organization: "{{ item.organization }}"
     description: "{{ item.description | default(omit) }}"
     tower_verify_ssl: "{{ tower_config_verify_ssl }}"
+    tower_username: "{{ tower_admin_username }}"
+    tower_password: "{{ tower_admin_password }}"
   no_log: "{{ tower_config_no_log }}"
   with_items: "{{ tower_config_teams }}"
 
@@ -42,6 +46,8 @@
     first_name: "{{ item.first_name }}"
     last_name: "{{ item.last_name }}"
     tower_verify_ssl: "{{ tower_config_verify_ssl }}"
+    tower_username: "{{ tower_admin_username }}"
+    tower_password: "{{ tower_admin_password }}"
   no_log: "{{ tower_config_no_log }}"
   with_items: "{{ tower_config_users }}"
 
@@ -51,6 +57,8 @@
     target_team: "{{ item.target_team }}"
     role: "{{ item.role }}"
     tower_verify_ssl: "{{ tower_config_verify_ssl }}"
+    tower_username: "{{ tower_admin_username }}"
+    tower_password: "{{ tower_admin_password }}"
   no_log: "{{ tower_config_no_log }}"
   with_items: "{{ tower_config_roles }}"
 
@@ -64,6 +72,8 @@
     password: "{{ item.password | default(omit) }}"
     host: "{{ item.host | default(omit) }}"
     tower_verify_ssl: "{{ tower_config_verify_ssl }}"
+    tower_username: "{{ tower_admin_username }}"
+    tower_password: "{{ tower_admin_password }}"
   no_log: "{{ tower_config_no_log }}"
   with_items: "{{ tower_config_credentials }}"
 
@@ -81,6 +91,8 @@
     scm_url: "{{ item.scm_url | default(omit) }}"
     scm_branch: "{{ item.scm_branch | default(omit) }}"
     tower_verify_ssl: "{{ tower_config_verify_ssl }}"
+    tower_username: "{{ tower_admin_username }}"
+    tower_password: "{{ tower_admin_password }}"
   no_log: "{{ tower_config_no_log }}"
   with_items: "{{ tower_config_projects }}"
 
@@ -90,6 +102,8 @@
     organization: "{{ item.organization }}"
     description: "{{ item.description | default(omit) }}"
     tower_verify_ssl: "{{ tower_config_verify_ssl }}"
+    tower_username: "{{ tower_admin_username }}"
+    tower_password: "{{ tower_admin_password }}"
   no_log: "{{ tower_config_no_log }}"
   with_items: "{{ tower_config_inventories }}"
 
@@ -107,6 +121,8 @@
     update_on_project_update: "{{ item.update_on_project_update | default(omit) }}"
     overwrite_vars: "{{ item.overwrite_vars | default(omit) }}"
     tower_verify_ssl: "{{ tower_config_verify_ssl }}"
+    tower_username: "{{ tower_admin_username }}"
+    tower_password: "{{ tower_admin_password }}"
   no_log: "{{ tower_config_no_log }}"
   with_items: "{{ tower_config_inventory_sources }}"
   retries: 5
@@ -129,6 +145,8 @@
     credentials: "{{ item.credentials | default(omit) }}"
     become_enabled: "{{ item.become_enabled | default(omit) }}"
     tower_verify_ssl: "{{ tower_config_verify_ssl }}"
+    tower_username: "{{ tower_admin_username }}"
+    tower_password: "{{ tower_admin_password }}"
   no_log: "{{ tower_config_no_log }}"
   with_items: "{{ tower_config_job_templates }}"
   retries: 5
@@ -147,6 +165,8 @@
     frequency: "{{ item.frequency | default(omit) }}"
     frequency_unit: "{{ item.frequency_unit | default(omit) }}"
     tower_verify_ssl: "{{ tower_config_verify_ssl }}"
+    tower_username: "{{ tower_admin_username }}"
+    tower_password: "{{ tower_admin_password }}"
   no_log: "{{ tower_config_no_log }}"
   with_items: "{{ tower_config_schedules }}"
   retries: 5

--- a/roles/tower-setup/defaults/main.yaml
+++ b/roles/tower-setup/defaults/main.yaml
@@ -16,14 +16,16 @@
 #  You should have received a copy of the GNU General Public License
 #  along with ansible-tower-cicd.  If not, see <http://www.gnu.org/licenses/>.
 
+tower_admin_username: admin
+tower_admin_password: password
 tower_setup_basename: ansible-tower-setup
 tower_setup_version: 3.5.0-1
 tower_setup_archive: "{{ tower_setup_basename }}-{{ tower_setup_version }}.tar.gz"
 tower_setup_release_url: "https://releases.ansible.com/ansible-tower/setup/{{ tower_setup_archive }}"
 tower_setup_config:
   create_preload_data: false
-  admin_username: admin
-  admin_password: password
+  admin_username: '{{ tower_admin_username }}'
+  admin_password: '{{ tower_admin_password }}'
   nginx_http_port: "80"
   nginx_https_port: "443"
   pg_host: "127.0.0.1"
@@ -64,8 +66,6 @@ tower_setup_license:
 
 tower_setup_cli_config:
   host: "{{ tower_setup_host }}"
-  username: "{{ tower_setup_config.admin_username }}"
-  password: "{{ tower_setup_config.admin_password }}"
   verify_ssl: false
   use_token: false
   verbose: false

--- a/roles/tower-setup/tasks/main.yaml
+++ b/roles/tower-setup/tasks/main.yaml
@@ -103,7 +103,6 @@
 # accept blank (null) values for configuration options.
 - name: Configure tower-cli
   become: yes
-  no_log: yes
   ini_file:
     path: /etc/tower/tower_cli.cfg
     section: general
@@ -122,7 +121,7 @@
   no_log: yes
   vars:
     license: "{{ tower_setup_license | from_json }}"
-  command: tower-cli setting modify LICENSE '{{ license | to_json }}'
+  command: tower-cli setting modify -u '{{ tower_admin_username }}' -p '{{ tower_admin_password }}' LICENSE '{{ license | to_json }}'
   when: tower_setup_license_configure | bool
   tags:
     - tower-license


### PR DESCRIPTION
Hi.

This PR removes the admin credentials from the `/etc/tower/tower_cli.cfg` file, instead using `tower_username` and `tower_password` parameters of Tower Ansible modules.

The motivation behind this is to secure Tower servers which are using this role by avoiding storing the admin credentials unencrypted in a configuration file.